### PR TITLE
run_measurement now checks if the running directory is a git repository and commits al changes on measurement (if it is).

### DIFF
--- a/doc/example.gitignore
+++ b/doc/example.gitignore
@@ -1,0 +1,9 @@
+# Ignore everything
+*
+
+# But not these files...
+!.gitignore
+!**/*.py
+!**/*.ipynb
+!*.yml
+!*.json

--- a/environment.yml
+++ b/environment.yml
@@ -25,3 +25,4 @@ dependencies:
   - versioningit
   - qtpy
   - pip
+  - gitpython

--- a/labcore/utils/misc.py
+++ b/labcore/utils/misc.py
@@ -204,7 +204,7 @@ def indent_text(text: str, level: int = 0) -> str:
 def get_environment_packages():
     """
     Generates a dictionary with the names of the installed packages and their current version.
-    It detects if a package was installed in development mode and places the current hash instead of the version.
+    It detects if a package was installed in development mode and places the current commit hash instead of the version.
     """
     packages = {}
     for dist in distributions():

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     packaging>=20.0
     xhistogram>=0.3.0
     versioningit>=1.1.0
+    gitpython>=3.1.0
 
 [options.package_data]
 labcore =


### PR DESCRIPTION
2 Changes happening with this PR:

1:
The run_measurement function now goes through all of the packages in the running environment and creates a json file with the version for each package and the commit hash if a package was installed in developer mode.

If a package has uncomitted changes, the logger will log a warning and a string saying 'uncommited-changes' will appear instead of the hash.

Question: should I simply log the warning and place the hash of the last commit? or should I make this crash and not let a measurement run unless they commit the code? Placing the hash of the commit when there are uncomitted changes feels wrong, because that is not the code that is actually running, but stopping the code from running on any change feels a little too restrictive.

2: 
The run_measurement function now checks if the current directory is a git repository. If it is, it will commit all present changes with a generic commit message and add the hash in the data as a json file. If the current working directory is not a git repository, it will simply log a warning. 

To make this work properly we should use the example.gitignore as the gitignore file for these repositories. They will by default ignore anything except python files, jupyternotebooks, and yml and json files in the root of the repository (not in any sub-folder)
