### PR TITLE
Fixes autoclosing of quantum machine manager

### DIFF
--- a/labcore/instruments/opx/sweep.py
+++ b/labcore/instruments/opx/sweep.py
@@ -71,7 +71,11 @@ class RecordOPXdata(AsyncRecord):
             cluster_name=config.cluster_name,
             octave=config.octave
         )
-        qmachine = qmachine_mgr.open_qm(config(), close_other_machines=True)
+
+        qmachine = qmachine_mgr.open_qm(config(), close_other_machines=False)
+        logger.info(f"current QM: {qmachine}, {qmachine.id}")
+
+        
         # if config.octave is not None:
         #     config.configure_octave(qmachine_mgr, qmachine)
 
@@ -149,10 +153,6 @@ class RecordOPXdata(AsyncRecord):
             qmachine.close()
             logger.info(f"QM with ID {qm_id} closed.")
         
-        manager.close()
-        logger.info(f"QMM closed.")
-        del self.communicator['qmachine']
-        del self.communicator['manager']
 
 
     def collect(self, batchsize: int = 100) -> Generator[Dict, None, None]:


### PR DESCRIPTION
The issue with the previous version was that people in the same cluster couldn't run measurements simultaneously: a common quantum machine manager was being used by both users of the cluster. This meant that one user closing the quantum machine manager was causing the measurements of the other user to crash. 