### PR TITLE
Add fallback import for QuantumMachinesManager

### DIFF
--- a/labcore/instruments/opx/machines.py
+++ b/labcore/instruments/opx/machines.py
@@ -1,4 +1,7 @@
-from qm.QuantumMachinesManager import QuantumMachinesManager
+try:
+    from qm.QuantumMachinesManager import QuantumMachinesManager
+except:
+    from qm.quantum_machines_manager import QuantumMachinesManager
 
 
 def close_my_qm(config, host, port):

--- a/labcore/instruments/opx/sweep.py
+++ b/labcore/instruments/opx/sweep.py
@@ -7,7 +7,10 @@ import logging
 import numpy as np
 
 from qm.qua import *
-from qm.QuantumMachinesManager import QuantumMachinesManager
+try:
+    from qm.QuantumMachinesManager import QuantumMachinesManager
+except:
+    from qm.quantum_machines_manager import QuantumMachinesManager
 
 from labcore.measurement import *
 from labcore.measurement.record import make_data_spec

--- a/labcore/setup_opx_measurements.py
+++ b/labcore/setup_opx_measurements.py
@@ -18,7 +18,7 @@ import ipywidgets as widgets
 try: 
     from qm.QuantumMachinesManager import QuantumMachinesManager, QuantumMachine
 except:
-    from qm.QuantumMachinesManager import QuantumMachinesManager
+    from qm.quantum_machines_manager import QuantumMachinesManager
     from qm import QuantumMachine
 
 from qm.qua import *


### PR DESCRIPTION
Quantum machines changed their import so this adds a try, except to use the new one if the old one fails