### PR TITLE
Using mixers with qm clusters

### DIFF
--- a/labcore/instruments/opx/mixer.py
+++ b/labcore/instruments/opx/mixer.py
@@ -357,6 +357,8 @@ class MixerConfig:
     opx_address: str
     #: OPX port
     opx_port: str
+    #: OPX cluster_name
+    opx_cluster_name: str
     #: spectrum analyzer
     analyzer: Spike
     #: the LO for the mixer
@@ -436,7 +438,15 @@ def calibrate_mixer(config: MixerConfig,
     if config.generator_power is not None:
         config.generator.power(config.generator_power)
 
-    qmm = QuantumMachinesManager.QuantumMachinesManager(host=config.opx_address, port=config.opx_port)
+    if config.opx_cluster_name is not None:
+        qmm = QuantumMachinesManager.QuantumMachinesManager(host=config.opx_address, 
+                                                            port=None,
+                                                            cluster_name=config.opx_cluster_name)
+    else:
+        qmm = QuantumMachinesManager.QuantumMachinesManager(host=config.opx_address, 
+                                                            port=config.opx_port,)
+
+
     qm = qmm.open_qm(config.qmconfig(), close_other_machines=False)
 
     try:

--- a/labcore/instruments/opx/mixer.py
+++ b/labcore/instruments/opx/mixer.py
@@ -36,7 +36,7 @@ class MixerCalibration:
     lo_frq
         LO frequency in Hz
     if_frq
-        IF frequency in Hz (we're taking the absolute)
+        IF frequency in Hz (can be positive or negative, depending on the sideband you want)
     analyzer
         SignalHound qcodes driver instance
     qm
@@ -314,7 +314,7 @@ class MixerCalibration:
         np.ndarray
             the imbalance coordinate at which the smallest leakage was found for the lower sideband
         """
-        self.setup_analyzer(self.lo_frq - np.abs(self.if_frq)) # LO - IF to calibrate out the lower sideband
+        self.setup_analyzer(self.lo_frq - self.if_frq) # LO - IF
         res = self._scan2d(self.sb_imbalance,
                            center=center, ranges=ranges, steps=steps,
                            title='SB imbalance scan',
@@ -341,7 +341,7 @@ class MixerCalibration:
             Options to pass to the `scipy.optimize.minimize(method='COBYLA')`.
             Will be passed via the `options` dictionary.
         """
-        self.setup_analyzer(self.lo_frq - np.abs(self.if_frq)) # LO - IF to calibrate out the lower sideband
+        self.setup_analyzer(self.lo_frq - self.if_frq) # LO - IF 
         res, nit = self._optimize2d(self.sb_imbalance,
                                initial_guess,
                                ranges=ranges,

--- a/labcore/setup_opx_measurements.py
+++ b/labcore/setup_opx_measurements.py
@@ -64,7 +64,13 @@ class Mixer:
             with program() as const_pulse:
                 with infinite_loop_():
                     play('constant', self.config.element_name)
-            qmm = QuantumMachinesManager(host=self.config.qmconfig.opx_address,
+            if self.config.qmconfig.cluster_name is not None:
+                qmm = QuantumMachinesManager(host=self.config.qmconfig.opx_address,
+                                        port=None, 
+                                        cluster_name=self.config.qmconfig.cluster_name,
+                                        **kwargs)
+            else:
+                qmm = QuantumMachinesManager(host=self.config.qmconfig.opx_address,
                                         port=self.config.qmconfig.opx_port, **kwargs)
             self.qmm = qmm
             qm = qmm.open_qm(self.config.qmconfig(), close_other_machines=False)
@@ -117,6 +123,7 @@ def add_mixer_config(qubit_name, analyzer, generator, readout=False, element_to_
         qmconfig=options.qm_config,
         opx_address=options.qm_config.opx_address,
         opx_port=options.qm_config.opx_port,
+        opx_cluster_name=options.qm_config.cluster_name,
         analyzer=analyzer,
         generator=generator,
         if_param=nestedAttributeFromString(options.parameters, f"{element_to_param_map}.IF"),


### PR DESCRIPTION
- edited the external mixer code to check if a cluster name is being passed in when making a quantum machines manager, and if so to use that and the host address to make a quantum machine.  This prevents OPXs on different clusters from interfering with each if a only the host and port are passed in
- Made sure the mixer tuning code works with negative IFs as well