### PR TITLE
Add entry-point to start the nameserver.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,4 @@ license = {text = "MIT"}
 
 [project.scripts]
 autoplot = "scripts.monitr_server:run_autoplot"
+pyro-ns = "scripts.pyro_nameserver:run_pyro_nameserver"

--- a/scripts/pyro_nameserver.py
+++ b/scripts/pyro_nameserver.py
@@ -1,0 +1,71 @@
+import argparse
+import logging
+import os
+import sys
+
+# Configure logging to output to console
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+def run_pyro_nameserver():
+    """
+    Run the Pyro4 nameserver directly in the terminal.
+    This allows stopping the server with Ctrl+C.
+    """
+    parser = argparse.ArgumentParser(
+        description="Start Pyro4 nameserver for QICK integration. "
+                    "The nameserver runs in the foreground and can be stopped with Ctrl+C."
+    )
+    parser.add_argument(
+        '--host',
+        '-n',
+        default='localhost',
+        help='Host address for the nameserver (default: localhost)'
+    )
+    parser.add_argument(
+        '--port',
+        '-p',
+        type=int,
+        default=8888,
+        help='Port number for the nameserver (default: 8888)'
+    )
+
+    args = parser.parse_args()
+
+    # Set required environment variables for Pyro4
+    os.environ["PYRO_SERIALIZERS_ACCEPTED"] = "pickle"
+    os.environ["PYRO_PICKLE_PROTOCOL_VERSION"] = "4"
+
+    logger.info(f"Starting Pyro4 nameserver on {args.host}:{args.port}")
+    logger.info("Press Ctrl+C to stop the nameserver")
+
+    # Build the command to execute pyro4-ns
+    cmd = [
+        "pyro4-ns",
+        "-n",
+        args.host,
+        "-p",
+        str(args.port),
+    ]
+
+    try:
+        # Replace the current process with pyro4-ns
+        # This will run pyro4-ns directly in the terminal
+        os.execvp("pyro4-ns", cmd)
+    except FileNotFoundError:
+        logger.error("pyro4-ns command not found. Please install Pyro4 with: pip install Pyro4")
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"Failed to start Pyro4 nameserver: {e}")
+        logger.error(f"Error type: {type(e).__name__}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run_pyro_nameserver()

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,3 +52,4 @@ labcore =
 console_scripts =
     reconstruct-data = scripts.reconstruct_safe_write_data:main
     autoplot = scripts.monitr_server:run_autoplot
+    pyro-ns = scripts.pyro_nameserver:run_pyro_nameserver

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ if __name__ == "__main__":
         entry_points={
             'console_scripts': [
                 'autoplot = scripts.monitr_server:run_autoplot',
+                'pyro-ns = scripts.pyro_nameserver:run_pyro_nameserver',
             ],
         },
     )


### PR DESCRIPTION
To start the pyro nameserver you can now simply run the terminal command:

```
pyro-ns
```

You can pass the host and port using the flags `--host` or `-n` (`-h` is reserved for help) <hostname/ipaddress> and `--port` or `-p`  \<port>