### PR TITLE
Fix autoplot: register hvplot xarray accessor and handle single-element plots

### DIFF
--- a/src/labcore/analysis/hvplotting.py
+++ b/src/labcore/analysis/hvplotting.py
@@ -30,6 +30,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
+import hvplot.xarray  # noqa: F401 — registers .hvplot accessor on xarray objects
 import numpy as np
 import pandas as pd
 import panel as pn
@@ -1064,7 +1065,11 @@ class ValuePlot(PlotNode):
                 )
             else:
                 raise NotImplementedError
-            plot = plot.cols(2)
+            if not isinstance(plot, str):
+                try:
+                    plot = plot.cols(2)
+                except AttributeError:
+                    pass
         return plot
 
     def fit_axis_options(self) -> Any:
@@ -1322,11 +1327,10 @@ def plot_xr_as_2d(
                     ylabel=dim_labels.get(y, y),
                     clabel=f"Mean {dim_labels.get(d, d)}",
                 )
-        # FIXME: QuadMesh object has no attribute 'cols' error for longsweep
         try:
             return plot.cols(1)
         except AttributeError:
-            return "*Not a valid plot* Attribute Error occurred"
+            return plot
 
     else:
         return "*Not a valid plot*"


### PR DESCRIPTION
## Summary

- Add `import hvplot.xarray` to `hvplotting.py` so the `.hvplot` accessor is registered on xarray objects (was causing `AttributeError: 'DataArray' object has no attribute 'hvplot'` on load)
- Fix `plot_xr_as_2d` to return the plot directly when `.cols()` is not available (single `QuadMesh` element has no `.cols()`, only multi-plot `Layout` objects do)
- Guard `.cols(2)` call in `plot_panel` the same way

## Root causes

`hvplot` requires an explicit submodule import (`hvplot.xarray`, `hvplot.pandas`) to register its accessors — `import hvplot` alone does not do it. Additionally, `.cols()` is a method on HoloViews `Layout` objects (produced by `+`-combining plots), not on individual elements like `QuadMesh`.